### PR TITLE
fix where last-real-continue-point gets set

### DIFF
--- a/data/goal_src/jak1/pc/features/speedruns.gc
+++ b/data/goal_src/jak1/pc/features/speedruns.gc
@@ -680,7 +680,6 @@
   )
 
 (defun get-on-flutflut ()
-  (generic-post-init)
   (case (-> *target* state)
     ((target-flut-stance target-racing)
       (send-event *target* 'end-mode)
@@ -693,7 +692,6 @@
   )
 
 (defun get-on-zoomer ()
-  (generic-post-init)
   (case (-> *target* state)
     ((target-flut-stance target-racing)
       (send-event *target* 'end-mode)
@@ -745,6 +743,7 @@
 (define *full-hp?* #f)
 
 (defun custom-reset-multi-post-init ()
+  (generic-post-init)
   (when *full-hp?* (full-hp))
   (cond
     (*tmp-flut?* (get-on-flutflut))


### PR DESCRIPTION
we should do this on post-init always, even if not on flut/zoomer. and we dont need to do it every time you manually get on flut/zoomer